### PR TITLE
Hotfix/add disposition params for s3 presign url api

### DIFF
--- a/libumccr/aws/libs3.py
+++ b/libumccr/aws/libs3.py
@@ -111,7 +111,7 @@ def bucket_exists(bucket) -> bool:
     return False
 
 
-def presign_s3_file(bucket: str, key: str) -> (bool, str):
+def presign_s3_file(bucket: str, key: str, content_disposition='inline') -> (bool, str):
     """
     Generate a presigned URL
     https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.generate_presigned_url
@@ -122,7 +122,7 @@ def presign_s3_file(bucket: str, key: str) -> (bool, str):
     :return tuple (bool, str): (true, signed_url) if success, otherwise (false, error message)
     """
     try:
-        return True, s3_client().generate_presigned_url('get_object', Params={'Bucket': bucket, 'Key': key})
+        return True, s3_client().generate_presigned_url('get_object', Params={'Bucket': bucket, 'Key': key, 'ResponseContentDisposition': content_disposition})
     except ClientError as e:
         message = f"Failed to sign the specified S3 object (s3://{bucket}/{key}). Exception - {e}"
         logger.error(message)

--- a/libumccr/aws/libs3.py
+++ b/libumccr/aws/libs3.py
@@ -111,7 +111,7 @@ def bucket_exists(bucket) -> bool:
     return False
 
 
-def presign_s3_file(bucket: str, key: str, content_disposition='inline') -> (bool, str):
+def presign_s3_file(bucket: str, key: str, content_disposition:str ='inline') -> (bool, str):
     """
     Generate a presigned URL
     https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.generate_presigned_url

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="libumccr",
-    version="0.4.0rc3",
+    version="0.4.0rc4",
     author="UMCCR and Contributors",
     author_email="services@umccr.org",
     description="UMCCR Reusable Python modules",


### PR DESCRIPTION
Fix:

- add `content_disposition` param in the `libumccr.aws.libs3.presign_s3_file` function. 
- Set default value `inline` will not change the default behaviour as before.

Refer: about `ResponseContentDisposition` Params in the boto3 s3 client, https://github.com/boto/boto3/issues/356#issuecomment-155919331
https://github.com/boto/boto3/issues/610#issuecomment-443878760

Link: 
apis of PR, https://github.com/umccr/data-portal-apis/pull/705
ui issues, https://github.com/umccr/data-portal-client/issues/342