### PR TITLE
Bumped CI toolchain versions

### DIFF
--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
 
     steps:
       - name: Checkout code
@@ -29,31 +29,28 @@ jobs:
           fetch-depth: 0
 
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@v3.70.2
+        uses: trufflesecurity/trufflehog@v3.82.9
         with:
-          path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
-          extra_args: --debug --only-verified
+          extra_args: --only-verified
 
       - name: Restore Localstack Image Cache if it exists
         id: cache-docker-localstack
         uses: actions/cache@v4
         with:
           path: ci/cache/docker/localstack
-          key: cache-docker-localstack-2.1
+          key: cache-docker-localstack-3.8
 
       - name: Update Localstack Image Cache if cache miss
         if: steps.cache-docker-localstack.outputs.cache-hit != 'true'
-        run: docker pull public.ecr.aws/localstack/localstack:2.1 && mkdir -p ci/cache/docker/localstack && docker image save public.ecr.aws/localstack/localstack:2.1 --output ./ci/cache/docker/localstack/localstack-2.1.tar
+        run: docker pull public.ecr.aws/localstack/localstack:3.8 && mkdir -p ci/cache/docker/localstack && docker image save public.ecr.aws/localstack/localstack:3.8 --output ./ci/cache/docker/localstack/localstack-3.8.tar
 
       - name: Use Localstack Image Cache if cache hit
         if: steps.cache-docker-localstack.outputs.cache-hit == 'true'
-        run: docker image load --input ./ci/cache/docker/localstack/localstack-2.1.tar
+        run: docker image load --input ./ci/cache/docker/localstack/localstack-3.8.tar
 
       - name: Set up compose stack
         run: |
-          docker-compose -f docker-compose.yml up -d
+          docker compose -f compose.yml up -d
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -74,4 +71,4 @@ jobs:
 
       - name: Tear down compose stack
         run: |
-          docker-compose -f docker-compose.yml down
+          docker compose -f compose.yml down

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.2.0
+    rev: v1.5.0
     hooks:
       - id: detect-secrets
         name: detect secrets
@@ -9,7 +9,7 @@ repos:
         exclude: yarn.lock
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-json

--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,9 @@ dist: clean
 
 # Usage: make testpypi version=0.2.0
 testpypi: dist/libumccr-$(version).tar.gz
-	@python3 -m twine upload --repository testpypi --sign dist/libumccr-$(version).tar.gz
-	@python3 -m twine upload --repository testpypi --sign dist/libumccr-$(version)-*.whl
+	@python3 -m twine upload --repository testpypi dist/libumccr-$(version).tar.gz
+	@python3 -m twine upload --repository testpypi dist/libumccr-$(version)-*.whl
 
 pypi: dist/libumccr-$(version).tar.gz
-	@python3 -m twine upload --sign dist/libumccr-$(version).tar.gz
-	@python3 -m twine upload --sign dist/libumccr-$(version)-*.whl
+	@python3 -m twine upload dist/libumccr-$(version).tar.gz
+	@python3 -m twine upload dist/libumccr-$(version)-*.whl

--- a/compose.yml
+++ b/compose.yml
@@ -1,10 +1,6 @@
-# NOTE: if we update the container image version in here, also do update GHA caches step in prbuild.yml
-version: '3.8'
-
 services:
-
   localstack:
-    image: public.ecr.aws/localstack/localstack:2.1
+    image: public.ecr.aws/localstack/localstack:3.8
     container_name: libumccr_localstack
     ports:
       - "4566:4566"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39,310,311,312}
+envlist = py{39,310,311,312,313}
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
* Dropped Python 3.7, 3.8
* Added Python 3.13
* Refactored Docker compose
* Dropped PyPI twine upload GPG signing
  It does not require anymore.
