### PR TITLE
Fixed datetime utcnow deprecation

### DIFF
--- a/libumccr/libdt.py
+++ b/libumccr/libdt.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 
 
 def get_utc_now_ts():
-    return int(datetime.utcnow().replace(tzinfo=timezone.utc).timestamp())
+    return int(datetime.now(timezone.utc).replace(tzinfo=timezone.utc).timestamp())
 
 
 def parse_last_modified_date(date_raw: str) -> datetime:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.9",
     extras_require={
         "dev": [
             "pipdeptree",


### PR DESCRIPTION
* Bumped minimum version required to Python3.9
